### PR TITLE
Prohibit use of concepts until the Ranges TS merges.

### DIFF
--- a/library-design-guidelines.md
+++ b/library-design-guidelines.md
@@ -94,6 +94,9 @@ they fit together, along with some more nebulous ideas of 'usability'.
    * When designing a class type, where possible it should be a "regular type" (to be defined), e.g., different objects are independent.
    * Use `std::addressof()` to obtain addresses based on generic parameters.
    * Prefer to specify nested types as a typedef for an _unspecified_ or _implementation-defined_ type, rather than as a class or enumeration type. This avoids over-constraining implementations.
+   * Do not use `requires` clauses or define new language-level
+     `concept`s until the introduction and fundamental concepts from
+     the Ranges TS have merged into the IS.
 
 
 ## How We Code It

--- a/library-design-guidelines.md
+++ b/library-design-guidelines.md
@@ -95,8 +95,8 @@ they fit together, along with some more nebulous ideas of 'usability'.
    * Use `std::addressof()` to obtain addresses based on generic parameters.
    * Prefer to specify nested types as a typedef for an _unspecified_ or _implementation-defined_ type, rather than as a class or enumeration type. This avoids over-constraining implementations.
    * Do not use `requires` clauses or define new language-level
-     `concept`s until the introduction and fundamental concepts from
-     the Ranges TS have merged into the IS.
+     `concept`s until the introduction (section 6) and fundamental
+     concepts (section 7) from the Ranges TS have merged into the IS.
 
 
 ## How We Code It


### PR DESCRIPTION
Per discussion of https://wg21.link/P0802R0 in Albuquerque 2017, in
http://wiki.edg.com/bin/view/Wg21albuquerque/P0802

Poll:
We should delay IS-targetting papers that are using `requires` clauses and/or
defining new `concept`s, as per p0802r0 Policy #1 “Build the Concepts
Foundations First?”
SF F  N  A SA
4  21 10 2  0